### PR TITLE
Value: return error for incomplete redirect responses

### DIFF
--- a/value.go
+++ b/value.go
@@ -18,8 +18,7 @@ import (
 // The Params type is a helper to pass parameter into the Value request
 // methods.  It may be used as:
 //
-//     value.Get(lpad.Params{"name": "value"})
-//
+//	value.Get(lpad.Params{"name": "value"})
 type Params map[string]string
 
 type Error struct {
@@ -242,8 +241,7 @@ var ErrNotFound = errors.New("resource not found")
 //
 // Since Get returns the value itself, it may be used as:
 //
-//     v, err := other.Link("some_link").Get(nil)
-//
+//	v, err := other.Link("some_link").Get(nil)
 func (v *Value) Get(params Params) (same *Value, err error) {
 	return v.do("GET", params, nil)
 }
@@ -361,10 +359,10 @@ func (v *Value) do(method string, params Params, body []byte) (value *Value, err
 	body, berr := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 
-	if method == "POST" && resp.StatusCode == 201 {
+	if (method == "POST" && resp.StatusCode == 201) || (method == "GET" && resp.StatusCode == 303) {
 		value.loc = resp.Header.Get("Location")
 		if value.loc == "" {
-			return nil, errors.New("Server returned 201 without Location")
+			return nil, errors.New("Server returned %d without Location")
 		}
 		return value.do("GET", nil, nil)
 	}

--- a/value.go
+++ b/value.go
@@ -18,7 +18,8 @@ import (
 // The Params type is a helper to pass parameter into the Value request
 // methods.  It may be used as:
 //
-//	value.Get(lpad.Params{"name": "value"})
+//     value.Get(lpad.Params{"name": "value"})
+//
 type Params map[string]string
 
 type Error struct {
@@ -241,7 +242,8 @@ var ErrNotFound = errors.New("resource not found")
 //
 // Since Get returns the value itself, it may be used as:
 //
-//	v, err := other.Link("some_link").Get(nil)
+//     v, err := other.Link("some_link").Get(nil)
+//
 func (v *Value) Get(params Params) (same *Value, err error) {
 	return v.do("GET", params, nil)
 }
@@ -359,10 +361,19 @@ func (v *Value) do(method string, params Params, body []byte) (value *Value, err
 	body, berr := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 
-	if (method == "POST" && resp.StatusCode == 201) || (method == "GET" && resp.StatusCode == 303) {
+	// Go used to return an error if the Location header was missing before
+	// Go 1.19. For backwards-compatibility, we keep the same error.
+	if method == "GET" && resp.StatusCode == 303 && resp.Header.Get("Location") == "" {
+		return nil, &url.Error{
+			Op:  "Get",
+			URL: req.URL.String(),
+			Err: fmt.Errorf("%d response missing Location header", resp.StatusCode),
+		}
+	}
+	if method == "POST" && resp.StatusCode == 201 {
 		value.loc = resp.Header.Get("Location")
 		if value.loc == "" {
-			return nil, errors.New("Server returned %d without Location")
+			return nil, errors.New("Server returned 201 without Location")
 		}
 		return value.do("GET", nil, nil)
 	}

--- a/value_test.go
+++ b/value_test.go
@@ -244,7 +244,7 @@ func (s *ValueS) TestGetRedirectWithoutLocation(c *C) {
 	testServer.PrepareResponse(303, headers, `{"ok": true}`)
 	v := lpad.NewValue(nil, "", testServer.URL+"/myvalue", nil)
 	_, err := v.Get(nil)
-	c.Assert(err, ErrorMatches, "Get : 303 response missing Location header")
+	c.Assert(err, ErrorMatches, "Server returned %d without Location")
 }
 
 func (s *ValueS) TestPost(c *C) {

--- a/value_test.go
+++ b/value_test.go
@@ -244,7 +244,7 @@ func (s *ValueS) TestGetRedirectWithoutLocation(c *C) {
 	testServer.PrepareResponse(303, headers, `{"ok": true}`)
 	v := lpad.NewValue(nil, "", testServer.URL+"/myvalue", nil)
 	_, err := v.Get(nil)
-	c.Assert(err, ErrorMatches, "Server returned %d without Location")
+	c.Assert(err, ErrorMatches, fmt.Sprintf("Get %q: 303 response missing Location header", testServer.URL+"/myvalue"))
 }
 
 func (s *ValueS) TestPost(c *C) {


### PR DESCRIPTION
`TestGetRedirectWithoutLocation` was dependent on the behavior of Go's `net/http` package, so it started failing when Go changed the behavior of 303 responses without a Location header (see: https://tip.golang.org/doc/go1.19#nethttppkgnethttp).

This reintroduces the error that Go used to return before 1.19, just for the specific case for which we had a test. It tries to keep backwards compatibility as much as possible, returning the exact same error type (and almost the same content) as old versions of Go would return.